### PR TITLE
fix: 初期状態でオプションを正しく読み込めない問題の修正

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -11,7 +11,7 @@ document.addEventListener("mouseup", (event) => {
 
     // ポップアップの表示位置を取得
     chrome.storage.local.get("position", (result) => {
-      const position = result.position;
+      const position = result.position || "top";
 
       let top, left;
       switch (position) {


### PR DESCRIPTION
## 変更点

- 拡張機能を導入した時点では，ストレージに `position` オプションが設定されていなかった．
- ストレージに `position` オプションがない場合はデフォルト値を使用するように変更